### PR TITLE
Fix calendar red dot

### DIFF
--- a/client/src/views/Calendar.vue
+++ b/client/src/views/Calendar.vue
@@ -39,10 +39,7 @@
     methods: {
       checkDate(date) {
         let today = new Date()
-        if (parseInt(date[5] + date[6]) < today.getMonth() + 1) {
-          return "red"
-        }
-        else if (parseInt(date[8] + date[9]) < today.getDate()) {
+        if (parseInt(date[5] + date[6]) < today.getMonth() + 1 && parseInt(date[8] + date[9]) < today.getDate()) {
           return "red"
         }
         else {


### PR DESCRIPTION
Closes #2 where a red dot would appear on a lend where it should have been green in the next month before today's date. This solves that issue by saying that **both conditions (month and date) need to be true** in order to show the red dot, otherwise, it must be green.